### PR TITLE
feat: 선배 신청 페이지 최초 진입 시 기존 신청 내역 조회 및 편집/조회 모드 전환 로직 추가

### DIFF
--- a/src/app/(WithLayout)/mypage/rookie/guideapply/page.tsx
+++ b/src/app/(WithLayout)/mypage/rookie/guideapply/page.tsx
@@ -1,6 +1,298 @@
+// 'use client'
+
+// import { useState } from 'react'
+
+// import SquareButton from '@/components/ui/Buttons/SquareButton'
+// import WorkPeriodPicker from '@/components/ui/CustomSelectes/WorkPeriodPicker'
+// import FileUploadCard from '@/components/ui/FileUpload/FileUploadCard'
+// import TextFieldCounter from '@/components/ui/Inputs/TextFieldCounter'
+// import CircleTag from '@/components/ui/Tags/CircleTag'
+// import { useAuthStore } from '@/store/useAuthStore'
+
+// type FileStatus = 'empty' | 'pending' | 'completed'
+
+// type GuideUpgradeInfo = {
+//   companyName: string
+//   isCompanyNamePublic: boolean
+//   jobPosition: string
+//   isCurrent: boolean
+//   workingStart: string
+//   workingEnd: string | null
+//   workingPeriod: string
+//   certificationPdfUrl: string
+// }
+
+// export default function GuideApplyPage() {
+//   const { tokens, user } = useAuthStore()
+
+//   // 입력 상태
+//   const [company, setCompany] = useState('')
+//   const [isCompanyNamePublic, setIsCompanyNamePublic] = useState(true)
+//   const [job, setJob] = useState('')
+//   const [workPeriod, setWorkPeriod] = useState({
+//     startYear: '',
+//     startMonth: '',
+//     endYear: '',
+//     endMonth: '',
+//     isCurrent: false,
+//   })
+//   const [files, setFiles] = useState<File[]>([])
+//   const [fileStatus, setFileStatus] = useState<FileStatus>('empty')
+
+//   // 제출 여부 + 조회 데이터
+//   const [submitted, setSubmitted] = useState(false)
+//   const [guideInfo, setGuideInfo] = useState<GuideUpgradeInfo | null>(
+//     null,
+//   )
+
+//   const handleSubmit = async () => {
+//     try {
+//       const formData = new FormData()
+//       formData.append('companyName', company)
+//       formData.append(
+//         'isCompanyNamePublic',
+//         String(isCompanyNamePublic),
+//       )
+//       formData.append('jobPosition', job)
+//       formData.append('isCurrent', String(workPeriod.isCurrent))
+
+//       const workingStart = `${workPeriod.startYear}-${workPeriod.startMonth.padStart(2, '0')}-01`
+//       formData.append('workingStart', workingStart)
+
+//       if (workPeriod.isCurrent) {
+//         formData.append('workingEnd', '')
+//       } else {
+//         const workingEnd = `${workPeriod.endYear}-${workPeriod.endMonth.padStart(2, '0')}-01`
+//         formData.append('workingEnd', workingEnd)
+//       }
+
+//       if (files[0]) {
+//         if (files[0].size > 10 * 1024 * 1024) {
+//           alert('파일은 최대 10MB까지만 업로드 가능합니다.')
+//           return
+//         }
+//         formData.append('certificationPdf', files[0])
+//       }
+
+//       // ✅ provider 분기 처리
+//       const fetchOptions: RequestInit = {
+//         method: 'POST',
+//         body: formData,
+//       }
+
+//       if (user?.provider === 'test' && tokens?.accessToken) {
+//         fetchOptions.headers = {
+//           Authorization: `Bearer ${tokens.accessToken}`,
+//         }
+//       } else {
+//         fetchOptions.credentials = 'include'
+//       }
+
+//       const res = await fetch(
+//         `${process.env.NEXT_PUBLIC_API_URL}/api/member/me/upgrade-to-guide`,
+//         fetchOptions,
+//       )
+
+//       if (!res.ok) {
+//         const errText = await res.text()
+//         throw new Error(errText || 'API 요청 실패')
+//       }
+
+//       console.log('✅ 업로드 성공')
+
+//       // ✅ 업로드 성공 후 → 조회 API 호출
+//       const infoOptions: RequestInit = {}
+//       if (user?.provider === 'test' && tokens?.accessToken) {
+//         infoOptions.headers = {
+//           Authorization: `Bearer ${tokens.accessToken}`,
+//         }
+//       } else {
+//         infoOptions.credentials = 'include'
+//       }
+
+//       const infoRes = await fetch(
+//         `${process.env.NEXT_PUBLIC_API_URL}/api/member/me/guide-upgrade-info`,
+//         infoOptions,
+//       )
+
+//       if (!infoRes.ok) {
+//         const errText = await infoRes.text()
+//         throw new Error(errText || '조회 API 요청 실패')
+//       }
+
+//       const infoData = await infoRes.json()
+//       console.log('📌 조회 결과:', infoData.result)
+
+//       setGuideInfo(infoData.result)
+//       setSubmitted(true)
+//     } catch (err) {
+//       console.error('❌ 업로드 실패:', err)
+//     }
+//   }
+
+//   const handleEdit = () => {
+//     setSubmitted(false)
+//   }
+
+//   return (
+//     <main className="gap-spacing-3xl ml-[65px] flex flex-col">
+//       {/* 제목 + 편집 버튼 */}
+//       <div className="flex items-center justify-between">
+//         <h1 className="font-heading2 text-label-strong">
+//           선배 신청내역
+//         </h1>
+//         {submitted && (
+//           <SquareButton
+//             variant="secondary"
+//             size="md"
+//             onClick={handleEdit}
+//           >
+//             편집
+//           </SquareButton>
+//         )}
+//       </div>
+
+//       <section className="py-spacing-md px-spacing-xs gap-spacing-3xl border-border-subtler flex flex-col rounded-sm border">
+//         {!submitted ? (
+//           <>
+//             {/* 입력 폼 */}
+//             <div className="gap-spacing-2xs flex flex-col">
+//               <label className="font-title4 text-label-strong">
+//                 회사명
+//               </label>
+//               <input
+//                 type="text"
+//                 value={company}
+//                 onChange={(e) => setCompany(e.target.value)}
+//                 placeholder="경력 인증 내역과 동일하게 입력해주세요."
+//                 className="border-border-subtle bg-fill-white p-spacing-2xs font-caption2-medium text-label-default placeholder:text-label-subtler focus:ring-label-primary rounded-2xs w-full border focus:outline-none focus:ring-1"
+//               />
+//               {/* 회사명 공개 여부 */}
+//               <label className="mt-2 flex items-center gap-2">
+//                 <input
+//                   type="checkbox"
+//                   checked={isCompanyNamePublic}
+//                   onChange={(e) =>
+//                     setIsCompanyNamePublic(e.target.checked)
+//                   }
+//                   className="border-border-subtle accent-fill-primary h-4 w-4 cursor-pointer rounded"
+//                 />
+//                 <span className="font-caption2-medium text-label-deep">
+//                   회사명 공개
+//                 </span>
+//               </label>
+//             </div>
+
+//             <div className="gap-spacing-2xs flex flex-col">
+//               <label className="font-title4 text-label-strong">
+//                 직무명
+//               </label>
+//               <TextFieldCounter
+//                 placeholder="직무명을 입력해주세요. (예: 프론트엔드 개발자)"
+//                 maxLength={16}
+//                 className="w-full"
+//                 radiusClassName="rounded-2xs"
+//                 onChange={(val) => setJob(val)}
+//               />
+//             </div>
+
+//             <WorkPeriodPicker
+//               value={workPeriod}
+//               onChange={setWorkPeriod}
+//             />
+
+//             <div className="gap-spacing-2xs flex flex-col">
+//               <label className="font-title4 text-label-strong">
+//                 경력 인증
+//               </label>
+//               <FileUploadCard
+//                 files={files}
+//                 status={fileStatus}
+//                 onChange={(newFiles, status) => {
+//                   setFiles(newFiles)
+//                   setFileStatus(status)
+//                 }}
+//               />
+//             </div>
+
+//             <div className="flex justify-end">
+//               <SquareButton
+//                 variant="primary"
+//                 size="lg"
+//                 className="px-spacing-lg"
+//                 onClick={handleSubmit}
+//               >
+//                 제출하기
+//               </SquareButton>
+//             </div>
+//           </>
+//         ) : (
+//           <>
+//             {/* ✅ 조회 모드 */}
+//             <div className="px-spacing-xs py-spacing-md gap-spacing-xl flex flex-col">
+//               <div className="gap-spacing-4xs flex flex-col">
+//                 <h2 className="font-title4 text-label-strong">
+//                   회사명
+//                 </h2>
+//                 <div className="gap-spacing-4xs py-spacing-5xs flex flex-row items-center">
+//                   <CircleTag variant="primary">
+//                     {guideInfo?.isCompanyNamePublic
+//                       ? '공개'
+//                       : '비공개'}
+//                   </CircleTag>
+//                   <span className="font-caption2-medium text-label-default">
+//                     {guideInfo?.companyName ||
+//                       '경력 인증 내역과 동일하게 입력됩니다.'}
+//                   </span>
+//                 </div>
+//               </div>
+
+//               <div className="gap-spacing-4xs flex flex-col">
+//                 <h2 className="font-title4 text-label-strong">
+//                   직무명
+//                 </h2>
+//                 <p className="font-caption2-medium text-label-default py-spacing-5xs">
+//                   {guideInfo?.jobPosition || '직무명을 입력해주세요.'}
+//                 </p>
+//               </div>
+
+//               <div className="gap-spacing-4xs flex flex-col">
+//                 <h2 className="font-title4 text-label-strong">
+//                   근무기간
+//                 </h2>
+//                 <p className="font-caption2-medium text-label-default py-spacing-5xs">
+//                   {guideInfo?.workingPeriod ||
+//                     '근무기간을 입력해주세요.'}
+//                 </p>
+//               </div>
+
+//               <div className="gap-spacing-4xs flex flex-col">
+//                 <h2 className="font-title4 text-label-strong">
+//                   경력 인증
+//                 </h2>
+//                 <div className="gap-spacing-4xs py-spacing-5xs flex flex-row items-center">
+//                   <CircleTag variant="primary">인증 완료</CircleTag>
+//                   <a
+//                     href={guideInfo?.certificationPdfUrl}
+//                     target="_blank"
+//                     rel="noopener noreferrer"
+//                     className="font-caption2-medium text-label-primary underline"
+//                   >
+//                     인증서 보기
+//                   </a>
+//                 </div>
+//               </div>
+//             </div>
+//           </>
+//         )}
+//       </section>
+//     </main>
+//   )
+// }
+
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 import SquareButton from '@/components/ui/Buttons/SquareButton'
 import WorkPeriodPicker from '@/components/ui/CustomSelectes/WorkPeriodPicker'
@@ -45,6 +337,42 @@ export default function GuideApplyPage() {
     null,
   )
 
+  // ✅ 페이지 진입 시 기존 신청 내역 조회
+  useEffect(() => {
+    const fetchGuideInfo = async () => {
+      try {
+        const infoOptions: RequestInit =
+          user?.provider === 'test' && tokens?.accessToken
+            ? {
+                headers: {
+                  Authorization: `Bearer ${tokens.accessToken}`,
+                },
+              }
+            : { credentials: 'include' }
+
+        const res = await fetch(
+          `${process.env.NEXT_PUBLIC_API_URL}/api/member/me/guide-upgrade-info`,
+          infoOptions,
+        )
+
+        if (!res.ok) {
+          console.log('📌 조회 결과 없음 (편집 모드 진입)')
+          return
+        }
+
+        const data = await res.json()
+        if (data.result) {
+          setGuideInfo(data.result)
+          setSubmitted(true) // ✅ 값 있으면 조회 모드로
+        }
+      } catch (err) {
+        console.error('❌ 조회 실패:', err)
+      }
+    }
+
+    fetchGuideInfo()
+  }, [user?.provider, tokens?.accessToken])
+
   const handleSubmit = async () => {
     try {
       const formData = new FormData()
@@ -75,18 +403,16 @@ export default function GuideApplyPage() {
       }
 
       // ✅ provider 분기 처리
-      const fetchOptions: RequestInit = {
-        method: 'POST',
-        body: formData,
-      }
-
-      if (user?.provider === 'test' && tokens?.accessToken) {
-        fetchOptions.headers = {
-          Authorization: `Bearer ${tokens.accessToken}`,
-        }
-      } else {
-        fetchOptions.credentials = 'include'
-      }
+      const fetchOptions: RequestInit =
+        user?.provider === 'test' && tokens?.accessToken
+          ? {
+              method: 'POST',
+              body: formData,
+              headers: {
+                Authorization: `Bearer ${tokens.accessToken}`,
+              },
+            }
+          : { method: 'POST', body: formData, credentials: 'include' }
 
       const res = await fetch(
         `${process.env.NEXT_PUBLIC_API_URL}/api/member/me/upgrade-to-guide`,
@@ -100,25 +426,22 @@ export default function GuideApplyPage() {
 
       console.log('✅ 업로드 성공')
 
-      // ✅ 업로드 성공 후 → 조회 API 호출
-      const infoOptions: RequestInit = {}
-      if (user?.provider === 'test' && tokens?.accessToken) {
-        infoOptions.headers = {
-          Authorization: `Bearer ${tokens.accessToken}`,
-        }
-      } else {
-        infoOptions.credentials = 'include'
-      }
+      // 업로드 성공 후 → 다시 조회
+      const infoOptions: RequestInit =
+        user?.provider === 'test' && tokens?.accessToken
+          ? {
+              headers: {
+                Authorization: `Bearer ${tokens.accessToken}`,
+              },
+            }
+          : { credentials: 'include' }
 
       const infoRes = await fetch(
         `${process.env.NEXT_PUBLIC_API_URL}/api/member/me/guide-upgrade-info`,
         infoOptions,
       )
 
-      if (!infoRes.ok) {
-        const errText = await infoRes.text()
-        throw new Error(errText || '조회 API 요청 실패')
-      }
+      if (!infoRes.ok) throw new Error('조회 API 요청 실패')
 
       const infoData = await infoRes.json()
       console.log('📌 조회 결과:', infoData.result)
@@ -167,7 +490,6 @@ export default function GuideApplyPage() {
                 placeholder="경력 인증 내역과 동일하게 입력해주세요."
                 className="border-border-subtle bg-fill-white p-spacing-2xs font-caption2-medium text-label-default placeholder:text-label-subtler focus:ring-label-primary rounded-2xs w-full border focus:outline-none focus:ring-1"
               />
-              {/* 회사명 공개 여부 */}
               <label className="mt-2 flex items-center gap-2">
                 <input
                   type="checkbox"
@@ -228,7 +550,7 @@ export default function GuideApplyPage() {
           </>
         ) : (
           <>
-            {/* ✅ 조회 모드 */}
+            {/* 조회 모드 */}
             <div className="px-spacing-xs py-spacing-md gap-spacing-xl flex flex-col">
               <div className="gap-spacing-4xs flex flex-col">
                 <h2 className="font-title4 text-label-strong">

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -5,7 +5,7 @@
 
 // import api from '@/lib/http/api'
 
-// type Provider = 'google' | 'kakao' | 'mock'
+// type Provider = 'google' | 'kakao' | 'test'
 
 // export type User = {
 //   id: string
@@ -19,37 +19,62 @@
 //   createdAt: string
 // }
 
-// type ApiResp<T> = {
-//   message: string
-//   result: T
-//   isSuccess: boolean
+// export type Tokens = {
+//   accessToken: string
+//   refreshToken: string
+// }
+
+// type ApiResp<T> = { message: string; result: T; isSuccess: boolean }
+
+// type TestLoginResult = {
+//   accessToken: string
+//   refreshToken: string
+//   memberId: string
+//   nickname: string
+//   role: 'ROOKIE' | 'GUIDE'
+//   tokenType: 'Bearer'
+// }
+
+// type CreateResult = {
+//   memberId: string
+//   nickname: string
+//   role: 'ROOKIE' | 'GUIDE'
 // }
 
 // type State = {
 //   user: User | null
 //   isLoggedIn: boolean
 //   loading: boolean
+//   tokens: Tokens | null
 //   init: () => Promise<void>
 //   login: (provider: Provider) => void
+//   // ✅ dev 전용
+//   loginTest: (nickname: string) => Promise<void>
+//   createRookie: () => Promise<CreateResult>
+//   createGuide: () => Promise<CreateResult>
+//   createAndLogin: (role: 'ROOKIE' | 'GUIDE') => Promise<void>
 //   logout: () => Promise<void>
-//   mockLogin: () => void // 👈 목데이터 로그인 추가
+//   setAuth: (payload: { user: User; tokens: Tokens }) => void
 // }
 
-// // 로컬스토리지에서 초기 상태 동기 로드
-// function getInitialAuth(): Pick<State, 'user' | 'isLoggedIn'> {
+// function getInitialAuth(): Pick<
+//   State,
+//   'user' | 'isLoggedIn' | 'tokens'
+// > {
 //   if (typeof window === 'undefined')
-//     return { user: null, isLoggedIn: false }
+//     return { user: null, isLoggedIn: false, tokens: null }
 //   try {
 //     const raw = localStorage.getItem('auth-storage')
-//     if (!raw) return { user: null, isLoggedIn: false }
+//     if (!raw) return { user: null, isLoggedIn: false, tokens: null }
 //     const parsed = JSON.parse(raw)
 //     const saved = parsed?.state ?? parsed
 //     return {
 //       user: saved?.user ?? null,
 //       isLoggedIn: Boolean(saved?.isLoggedIn),
+//       tokens: saved?.tokens ?? null,
 //     }
 //   } catch {
-//     return { user: null, isLoggedIn: false }
+//     return { user: null, isLoggedIn: false, tokens: null }
 //   }
 // }
 
@@ -58,15 +83,22 @@
 // export const useAuthStore = create<State>()(
 //   persist(
 //     (set, get) => ({
-//       // ✅ 첫 렌더부터 저장된 로그인 상태로 시작
 //       user: initial.user,
 //       isLoggedIn: initial.isLoggedIn,
+//       tokens: initial.tokens,
 //       loading: false,
 
-//       // 로그인 상태 확인 + 유저 정보 가져오기
 //       init: async () => {
 //         set({ loading: true })
 //         try {
+//           const hasToken =
+//             typeof window !== 'undefined' &&
+//             !!localStorage.getItem('accessToken')
+//           if (hasToken) {
+//             const me = await api.get<ApiResp<User>>('/api/member/me')
+//             set({ user: me.data.result, isLoggedIn: true })
+//             return
+//           }
 //           const status = await api.get<ApiResp<boolean>>(
 //             '/api/auth/status',
 //           )
@@ -74,79 +106,104 @@
 //             const me = await api.get<ApiResp<User>>('/api/member/me')
 //             set({ user: me.data.result, isLoggedIn: true })
 //           } else {
-//             set({ user: null, isLoggedIn: false })
+//             set({ user: null, isLoggedIn: false, tokens: null })
 //           }
 //         } catch (e) {
 //           console.error('init 실패:', e)
-//           set({ user: null, isLoggedIn: false })
+//           set({ user: null, isLoggedIn: false, tokens: null })
 //         } finally {
 //           set({ loading: false })
 //         }
 //       },
 
-//       // 실제 로그인 시작
 //       login: (provider) => {
 //         window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/api/oauth2/authorization/${provider}`
 //       },
 
-//       // // 로그아웃
-//       // logout: async () => {
-//       //   try {
-//       //     await api.post('/api/auth/logout')
-//       //     set({ user: null, isLoggedIn: false })
-//       //     window.location.href = '/login'
-//       //   } catch (e) {
-//       //     console.error('로그아웃 실패:', e)
-//       //   }
-//       // },
-
-//       // 로그아웃 - 목데이터 추가 버전
-//       logout: async () => {
-//         try {
-//           const currentUser = get().user
-//           // 목데이터 로그인일 경우
-//           if (currentUser?.provider === 'mock') {
-//             set({ user: null, isLoggedIn: false })
-//             window.location.assign('/')
-//             return
-//           }
-
-//           await api.post('/api/auth/logout')
-//           set({ user: null, isLoggedIn: false })
-//           window.location.assign('/')
-//         } catch (e) {
-//           console.error('로그아웃 실패:', e)
-//           set({ user: null, isLoggedIn: false })
-//           window.location.assign('/')
+//       // ===== dev 전용 API들 =====
+//       loginTest: async (nickname: string) => {
+//         const { data } = await api.post<ApiResp<TestLoginResult>>(
+//           '/api/test/auth/login',
+//           { nickname },
+//         )
+//         const r = data.result
+//         localStorage.setItem('accessToken', r.accessToken)
+//         localStorage.setItem('refreshToken', r.refreshToken)
+//         const me = await api.get<ApiResp<User>>('/api/member/me')
+//         const fullUser = {
+//           ...me.data.result,
+//           provider: 'test' as const,
 //         }
-//       },
-//       // 목데이터 로그인
-//       mockLogin: () => {
 //         set({
-//           user: {
-//             id: 'mock-1',
-//             nickname: '오뎅🍥',
-//             role: 'ROOKIE',
-//             phoneNumber: null,
-//             point: 999,
-//             profileImageUrl: null,
-//             description: '안녕하세요, 후배 오뎅 입니다.',
-//             provider: 'mock',
-//             createdAt: new Date().toISOString(),
+//           user: fullUser,
+//           tokens: {
+//             accessToken: r.accessToken,
+//             refreshToken: r.refreshToken,
 //           },
 //           isLoggedIn: true,
 //         })
 //       },
+
+//       createRookie: async () => {
+//         const { data } = await api.post<ApiResp<CreateResult>>(
+//           '/api/test/auth/create-rookie',
+//         )
+//         return data.result
+//       },
+
+//       createGuide: async () => {
+//         const { data } = await api.post<ApiResp<CreateResult>>(
+//           '/api/test/auth/create-guide',
+//         )
+//         return data.result
+//       },
+
+//       // 원클릭: 생성 → 로그인
+//       createAndLogin: async (role) => {
+//         const create =
+//           role === 'ROOKIE' ? get().createRookie : get().createGuide
+//         const { nickname } = await create()
+//         await get().loginTest(nickname)
+//       },
+
+//       logout: async () => {
+//         try {
+//           const provider = get().user?.provider
+//           if (provider === 'test') {
+//             localStorage.removeItem('accessToken')
+//             localStorage.removeItem('refreshToken')
+//             set({ user: null, isLoggedIn: false, tokens: null })
+//             window.location.assign('/')
+//             return
+//           }
+//           await api.post('/api/auth/logout')
+//           localStorage.removeItem('accessToken')
+//           localStorage.removeItem('refreshToken')
+//           set({ user: null, isLoggedIn: false, tokens: null })
+//           window.location.assign('/')
+//         } catch (e) {
+//           console.error('로그아웃 실패:', e)
+//           localStorage.removeItem('accessToken')
+//           localStorage.removeItem('refreshToken')
+//           set({ user: null, isLoggedIn: false, tokens: null })
+//           window.location.assign('/')
+//         }
+//       },
+
+//       setAuth: ({ user, tokens }) =>
+//         set({ user, tokens, isLoggedIn: true }),
 //     }),
 //     {
-//       name: 'auth-storage', // localStorage 키 이름
-//       partialize: (state) => ({
-//         user: state.user,
-//         isLoggedIn: state.isLoggedIn,
+//       name: 'auth-storage',
+//       partialize: (s) => ({
+//         user: s.user,
+//         isLoggedIn: s.isLoggedIn,
+//         tokens: s.tokens,
 //       }),
 //     },
 //   ),
 // )
+
 'use client'
 
 import { create } from 'zustand'
@@ -197,13 +254,13 @@ type State = {
   tokens: Tokens | null
   init: () => Promise<void>
   login: (provider: Provider) => void
-  // ✅ dev 전용
   loginTest: (nickname: string) => Promise<void>
   createRookie: () => Promise<CreateResult>
   createGuide: () => Promise<CreateResult>
   createAndLogin: (role: 'ROOKIE' | 'GUIDE') => Promise<void>
   logout: () => Promise<void>
   setAuth: (payload: { user: User; tokens: Tokens }) => void
+  refreshUser: () => Promise<void> // ✅ 추가
 }
 
 function getInitialAuth(): Pick<
@@ -269,7 +326,6 @@ export const useAuthStore = create<State>()(
         window.location.href = `${process.env.NEXT_PUBLIC_API_URL}/api/oauth2/authorization/${provider}`
       },
 
-      // ===== dev 전용 API들 =====
       loginTest: async (nickname: string) => {
         const { data } = await api.post<ApiResp<TestLoginResult>>(
           '/api/test/auth/login',
@@ -307,7 +363,6 @@ export const useAuthStore = create<State>()(
         return data.result
       },
 
-      // 원클릭: 생성 → 로그인
       createAndLogin: async (role) => {
         const create =
           role === 'ROOKIE' ? get().createRookie : get().createGuide
@@ -341,6 +396,21 @@ export const useAuthStore = create<State>()(
 
       setAuth: ({ user, tokens }) =>
         set({ user, tokens, isLoggedIn: true }),
+
+      // ✅ 여기 추가
+      refreshUser: async () => {
+        try {
+          const res = await api.get<ApiResp<User>>('/api/member/me')
+          const fullUser = {
+            ...res.data.result,
+            provider: get().user?.provider ?? 'google',
+          }
+          set({ user: fullUser, isLoggedIn: true })
+        } catch (e) {
+          console.error('refreshUser 실패:', e)
+          set({ user: null, isLoggedIn: false })
+        }
+      },
     }),
     {
       name: 'auth-storage',


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 선배 신청 페이지 진입 시 기존 신청 내역 자동 조회 및 편집/조회 모드 전환 로직 추가

# 🛠️ What’s been done?

	•	GuideApplyPage 컴포넌트 진입 시 /api/member/me/guide-upgrade-info API 호출하도록 로직 추가
	•	조회 데이터가 있을 경우 조회 모드로, 없을 경우 편집 모드로 초기화
	•	oauth와 testAuth 환경에 따라 Authorization 헤더/쿠키 분기 처리 추가
	•	불필요한 useEffect dependency warning 해결 (getAuthOptions 분리 → inline 함수 처리)

# 🧪 Testing Details

	•	테스트 환경: 로컬 환경에서 testAuth 및 oauth 각각 테스트
	•	testAuth 모드 → Bearer Token 헤더로 API 호출 성공
	•	oauth 모드 → HttpOnly 쿠키 인증 정상 동작 확인
	•	결과:
	•	기존 내역 없을 시 → 편집 모드 표시
	•	기존 내역 있을 시 → 조회 모드 정상 전환

# 👀 Checkpoints for Reviewers

	- fetchUpgradeInfo 로직이 oauth/testAuth 모두 안전하게 동작하는지 확인 필요
	-	조회 모드 → 편집 모드 전환 UX 플로우 괜찮은지 리뷰 요청
	-	FormData 전송 시 백엔드 DTO와 매칭되는지 재확인 필요

# 📚 References & Resources

	•	[백엔드 API 스펙 문서] /api/member/me/guide-upgrade-info
	•	zustand useAuthStore 상태관리 로직 (user.provider 기준 분기 참고)

# 🎯 Related Issues

- #21