### PR TITLE
fix: 선배 커피챗 등록/예약 개선 및 후배 프로필 반영 문제 수정

### DIFF
--- a/src/app/(WithLayout)/(common)/coffeechatApply/[id]/page.tsx
+++ b/src/app/(WithLayout)/(common)/coffeechatApply/[id]/page.tsx
@@ -17,6 +17,7 @@ import {
   postReservation,
 } from '@/lib/http/reservations'
 import { useModalStore } from '@/store/useModalStore'
+
 import ApplyComplete from '../_components/ApplyComplete'
 
 export default function CoffeechatApplyPage() {

--- a/src/app/(WithLayout)/(common)/coffeechatApply/[id]/page.tsx
+++ b/src/app/(WithLayout)/(common)/coffeechatApply/[id]/page.tsx
@@ -9,14 +9,14 @@ import SquareButton from '@/components/ui/Buttons/SquareButton'
 import DateTimeSelector from '@/components/ui/CustomSelectes/DateTimeSelector'
 import ScheduleInputView from '@/components/ui/CustomSelectes/Schedule/ScheduleInputView'
 import { Schedule } from '@/components/ui/CustomSelectes/Schedule/ScheduleSelector'
-import FileUploadCard from '@/components/ui/FileUpload/FileUploadCard'
+import CoffeechatApplyFileUpload from '@/components/ui/FileUpload/CoffeechatApplyFileUpload'
 import TextAreaCounter from '@/components/ui/Inputs/TextAreaCounter'
 import {
   getReservationApply,
   getGuideSchedules,
   postReservation,
 } from '@/lib/http/reservations'
-
+import { useModalStore } from '@/store/useModalStore'
 import ApplyComplete from '../_components/ApplyComplete'
 
 export default function CoffeechatApplyPage() {
@@ -120,8 +120,26 @@ export default function CoffeechatApplyPage() {
       console.log('✅ 예약 성공:', res)
       setReservationId(res.data.reservationId)
       setIsSubmitted(true)
-    } catch (err) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (err: any) {
       console.error('❌ 예약 실패:', err)
+      const { openModal } = useModalStore.getState()
+
+      // 에러 메시지 안에 "본인"이 포함된 경우 모달 표시
+      if (err?.response?.data?.message?.includes('본인')) {
+        openModal({
+          title: '예약 불가',
+          message: '본인에게는 커피챗을 신청할 수 없습니다.',
+          confirmText: '확인',
+        })
+      } else {
+        openModal({
+          title: '예약 실패',
+          message:
+            err?.response?.data?.message ||
+            '예약에 실패했습니다. 다시 시도해주세요.',
+        })
+      }
     }
   }
 
@@ -179,12 +197,12 @@ export default function CoffeechatApplyPage() {
                   </div>
                 </div>
 
-                {/* 사진 공유 자료 선택 */}
+                {/* 사전 공유 자료 선택 */}
                 <div className="gap-spacing-sm flex flex-col">
                   <h3 className="font-title4 text-label-strong">
-                    사진 공유 자료 선택
+                    사전 공유 자료 선택
                   </h3>
-                  <FileUploadCard
+                  <CoffeechatApplyFileUpload
                     onChange={(files) => setUploadedFiles(files)}
                   />
                 </div>

--- a/src/app/(WithLayout)/(common)/searchGuide/_components/MentorPage.tsx
+++ b/src/app/(WithLayout)/(common)/searchGuide/_components/MentorPage.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useState, useMemo } from 'react'
 
 import EmptyState from '@/components/common/EmptyState'
+import Loading from '@/components/common/LoadingState'
 import UploadCard from '@/components/ui/Cards/UploadCard'
 import SelectedChips from '@/components/ui/Chips/SelectedChips'
 import Pagination from '@/components/ui/Paginations/Pagination'
@@ -140,9 +141,7 @@ export default function MentorPage() {
           />
 
           {loading ? (
-            <div className="text-label-default py-20 text-center">
-              로딩 중...
-            </div>
+            <Loading />
           ) : paginatedMentors.length === 0 ? (
             <EmptyState />
           ) : (

--- a/src/app/(WithLayout)/(common)/searchGuide/page.tsx
+++ b/src/app/(WithLayout)/(common)/searchGuide/page.tsx
@@ -1,10 +1,34 @@
-import { Suspense } from 'react'
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { Suspense, useEffect } from 'react'
 
 import Loading from '@/components/common/LoadingState'
+import { useAuthStore } from '@/store/useAuthStore'
+import { useModalStore } from '@/store/useModalStore'
 
 import MentorPage from './_components/MentorPage'
 
 export default function SearchGuidePage() {
+  const { user, isHydrated } = useAuthStore()
+  const { openModal, closeModal } = useModalStore()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!isHydrated) return
+    if (!user) {
+      openModal({
+        title: '로그인이 필요합니다',
+        message: '로그인 후 이용할 수 있는 서비스입니다.',
+        confirmText: '로그인하기',
+        onConfirm: () => {
+          closeModal()
+          router.push('/login') // ✅ 로그인 페이지로 리다이렉트
+        },
+      })
+    }
+  }, [user, openModal, closeModal, router, isHydrated])
+
   return (
     <Suspense fallback={<Loading />}>
       <MentorPage />

--- a/src/app/(WithLayout)/mypage/guide/dashboard/_components/CoffeeChatVisibleToggle.tsx
+++ b/src/app/(WithLayout)/mypage/guide/dashboard/_components/CoffeeChatVisibleToggle.tsx
@@ -1,33 +1,47 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-
 import LabeledToggle from '@/components/ui/Toggle/LabledToggle'
 import api from '@/lib/http/api'
+import { useAuthStore } from '@/store/useAuthStore'
 
 export default function GuideVisibilityToggle() {
   const [opened, setOpened] = useState<boolean>(true)
-  const [loading, setLoading] = useState(false)
+  const [_loading, setLoading] = useState(false)
+
+  const guideId = useAuthStore((s) => s.guideId)
+  const isHydrated = useAuthStore((s) => s.isHydrated)
 
   // ✅ 초기값 불러오기
   useEffect(() => {
     const fetchInitial = async () => {
+      if (!isHydrated) return
+      if (!guideId) {
+        console.warn('⚠️ guideId 없음 → 공개 상태 불러오기 불가')
+        return
+      }
       try {
-        const res = await api.get('/api/guides/me/coffeechats')
-        setOpened(res.data.data.opened) // 👈 응답에서 opened만 사용
+        // ✅ 스펙에 맞게 수정
+        const res = await api.get(
+          `/api/guides/${guideId}/coffeechats`,
+        )
+        const state = res.data.data.isOpened ?? res.data.data.opened
+        setOpened(state ?? true)
       } catch (err) {
         console.error('❌ 초기 공개 상태 불러오기 실패:', err)
       }
     }
     fetchInitial()
-  }, [])
+  }, [isHydrated, guideId])
 
   // ✅ 토글 핸들러
   const handleToggle = async (value: boolean) => {
     setOpened(value)
     setLoading(true)
     try {
-      await api.patch('/api/guides/me/visibility', { opened: value })
+      await api.patch('/api/guides/me/visibility', {
+        isOpened: value,
+      })
       console.log('✅ 공개 상태 변경 성공:', value)
     } catch (err) {
       console.error('❌ 공개 상태 변경 실패:', err)
@@ -39,7 +53,7 @@ export default function GuideVisibilityToggle() {
 
   return (
     <LabeledToggle
-      label={loading ? '커피챗 공개 여부' : '커피챗 공개 여부'}
+      label="커피챗 공개 여부"
       checked={opened}
       onChange={handleToggle}
     />

--- a/src/app/(WithLayout)/mypage/guide/mycoffeechat/page.tsx
+++ b/src/app/(WithLayout)/mypage/guide/mycoffeechat/page.tsx
@@ -393,7 +393,7 @@ import { useAuthStore } from '@/store/useAuthStore'
 interface Experience {
   title: string
   content: string
-  categories: string[]
+  category: string | null
 }
 
 // 요일 변환
@@ -424,13 +424,13 @@ export default function CoffeechatRegisterPage() {
 
   // Step 1 데이터
   const [title, setTitle] = useState('')
-  const [jobFields, setJobFields] = useState<string[]>([])
+  const [jobField, setJobField] = useState<string | null>(null) // 단일 선택
   // const [topics] = useState<string[]>([])
   const [schedules, setSchedules] = useState<Schedule[]>([])
 
   // Step 2 데이터
   const [experiences, setExperiences] = useState<Experience[]>([
-    { title: '', content: '', categories: [] },
+    { title: '', content: '', category: null },
   ])
   const [intro, setIntro] = useState('')
   const [tags, setTags] = useState<string[]>(['', '', '', '', ''])
@@ -444,7 +444,7 @@ export default function CoffeechatRegisterPage() {
   const addExperience = () => {
     setExperiences([
       ...experiences,
-      { title: '', content: '', categories: [] },
+      { title: '', content: '', category: null },
     ])
   }
 
@@ -452,7 +452,7 @@ export default function CoffeechatRegisterPage() {
   const updateExperience = (
     index: number,
     field: keyof Experience,
-    value: string | string[],
+    value: string | null,
   ) => {
     const newExps = [...experiences]
     newExps[index] = { ...newExps[index], [field]: value }
@@ -477,9 +477,9 @@ export default function CoffeechatRegisterPage() {
       }
 
       // 2) 직무 분야 등록
-      if (jobFields.length > 0) {
+      if (jobField) {
         await api.post('/api/guides/me/job-field', {
-          jobName: jobFields[0],
+          jobName: jobField,
         })
         console.log('✅ 직무 분야 등록 성공')
       }
@@ -543,7 +543,7 @@ export default function CoffeechatRegisterPage() {
       if (experiences.length > 0) {
         // ✅ 경험마다 주제 선택 여부 확인
         for (const exp of experiences) {
-          if (!exp.categories[0]) {
+          if (!exp.category) {
             alert('경험마다 주제를 1개 이상 선택해야 합니다.')
             return
           }
@@ -551,7 +551,7 @@ export default function CoffeechatRegisterPage() {
 
         const expPayload = {
           groups: experiences.map((exp) => ({
-            topicName: exp.categories[0], // ✅ 이제 topicName으로 보냄
+            topicName: exp.category, // ✅ 이제 topicName으로 보냄
             experienceTitle: exp.title,
             experienceContent: exp.content,
           })),
@@ -569,6 +569,12 @@ export default function CoffeechatRegisterPage() {
       alert('등록 실패')
     }
   }
+
+  // ===== 선택 해제 핸들러 =====
+  const handleRemoveJobField = () => {
+    setJobField(null) // ✅ 단일 선택 → 그냥 비워줌
+  }
+
   // ================== UI (원본 그대로) ==================
   return (
     <main className="gap-spacing-3xl py-spacing-5xl ml-[84px] flex flex-col">
@@ -605,16 +611,12 @@ export default function CoffeechatRegisterPage() {
               </label>
               <div className="flex flex-col gap-[20px]">
                 <SelectedChips
-                  selected={jobFields}
-                  onRemove={(val) =>
-                    setJobFields((prev) =>
-                      prev.filter((f) => f !== val),
-                    )
-                  }
+                  selected={jobField ? [jobField] : []} // ✅ 배열로 변환
+                  onRemove={handleRemoveJobField}
                 />
                 <JobFieldFilter
-                  selected={jobFields}
-                  onChange={setJobFields}
+                  selected={jobField}
+                  onChange={setJobField}
                 />
               </div>
             </div>
@@ -778,9 +780,9 @@ export default function CoffeechatRegisterPage() {
                   <div className="gap-spacing-4xs flex flex-col">
                     <label>주제분류</label>
                     <CategoryFilter
-                      selected={exp.categories}
-                      onChange={(vals) =>
-                        updateExperience(idx, 'categories', vals)
+                      selected={exp.category}
+                      onChange={(val) =>
+                        updateExperience(idx, 'category', val)
                       }
                     />
                   </div>

--- a/src/app/(WithLayout)/mypage/guide/mycoffeechat/page.tsx
+++ b/src/app/(WithLayout)/mypage/guide/mycoffeechat/page.tsx
@@ -1,381 +1,3 @@
-// 'use client'
-
-// import { useState } from 'react'
-
-// import SquareButton from '@/components/ui/Buttons/SquareButton'
-// import SelectedChips from '@/components/ui/Chips/SelectedChips'
-// import ScheduleInput from '@/components/ui/CustomSelectes/Schedule/ScheduleInput'
-// import { Schedule } from '@/components/ui/CustomSelectes/Schedule/ScheduleSelector'
-// import CategoryFilter from '@/components/ui/Filters/CategoryFilter'
-// import JobFieldFilter from '@/components/ui/Filters/JobFieldFilter'
-
-// // 경험 항목 타입
-// interface Experience {
-//   title: string
-//   content: string
-//   categories: string[]
-// }
-
-// export default function CoffeechatRegisterPage() {
-//   // 단계 관리
-//   const [step, setStep] = useState(1)
-
-//   // Step 1 데이터
-//   const [title, setTitle] = useState('')
-//   const [jobFields, setJobFields] = useState<string[]>([])
-//   const [topics] = useState<string[]>([])
-//   const [schedules, setSchedules] = useState<Schedule[]>([])
-
-//   // Step 2 데이터
-//   const [experiences, setExperiences] = useState<Experience[]>([
-//     { title: '', content: '', categories: [] },
-//   ])
-//   const [intro, setIntro] = useState('')
-//   const [tags, setTags] = useState<string[]>(['', '', '', '', ''])
-
-//   // ✅ Step2에서 경험 목록 추가
-//   const addExperience = () => {
-//     setExperiences([
-//       ...experiences,
-//       { title: '', content: '', categories: [] },
-//     ])
-//   }
-
-//   // ✅ 경험 항목 업데이트
-//   const updateExperience = (
-//     index: number,
-//     field: keyof Experience,
-//     value: string | string[],
-//   ) => {
-//     const newExps = [...experiences]
-//     newExps[index] = { ...newExps[index], [field]: value }
-//     setExperiences(newExps)
-//   }
-
-//   // 최종 제출
-//   const handleSubmit = () => {
-//     const payload = {
-//       title,
-//       jobFields,
-//       topics,
-//       experiences,
-//       intro,
-//       tags,
-//     }
-//     console.log('📦 최종 폼 데이터:', payload)
-//     alert('등록 완료!')
-//   }
-
-//   return (
-//     <main className="gap-spacing-3xl py-spacing-5xl ml-[84px] flex flex-col">
-//       {step === 1 && (
-//         <>
-//           <h2 className="font-heading2 text-label-strong">
-//             커피챗 등록하기
-//           </h2>
-//           <section className="border-border-subtler bg-fill-white px-spacing-xs py-spacing-md flex flex-col gap-[80px] rounded-sm border">
-//             {/* 커피챗 제목 */}
-//             <div className="gap-spacing-sm flex flex-col">
-//               <label className="font-title4 text-label-strong">
-//                 커피챗 제목
-//               </label>
-//               <div className="relative">
-//                 <input
-//                   type="text"
-//                   value={title}
-//                   onChange={(e) => setTitle(e.target.value)}
-//                   maxLength={70}
-//                   placeholder="토론할 수 있는 커피챗 제목을 입력해주세요."
-//                   className="border-border-subtler bg-fill-white p-spacing-3xs font-caption2-medium text-label-default placeholder:text-label-subtler rounded-2xs focus:ring-label-primary w-full border focus:outline-none focus:ring-1"
-//                 />
-//                 <span className="text-label-subtler right-spacing-3xs font-caption2-medium absolute top-1/2 -translate-y-1/2 text-right">
-//                   {title.length}/70
-//                 </span>
-//               </div>
-//             </div>
-
-//             {/* 커피챗 분야 */}
-//             <div className="gap-spacing-sm flex flex-col">
-//               <label className="font-title4 text-label-strong">
-//                 커피챗 분야
-//               </label>
-//               <div className="flex flex-col gap-[20px]">
-//                 <SelectedChips
-//                   selected={jobFields}
-//                   onRemove={(val) =>
-//                     setJobFields((prev) =>
-//                       prev.filter((f) => f !== val),
-//                     )
-//                   }
-//                 />
-//                 <JobFieldFilter
-//                   selected={jobFields}
-//                   onChange={setJobFields}
-//                 />
-//               </div>
-//             </div>
-
-//             {/* 커피챗 주제 */}
-//             <div className="gap-spacing-sm flex w-fit flex-col">
-//               <div className="gap-spacing-2xs flex flex-col">
-//                 <label className="font-title4 text-label-strong">
-//                   커피챗 신청 받을 일정을 선택해주세요.
-//                 </label>
-//                 <p className="font-caption2-medium text-label-subtle">
-//                   일정을 추가하고 싶다면 활동 일정을 추가해주세요.
-//                 </p>
-//               </div>
-//               <ScheduleInput
-//                 schedules={schedules}
-//                 onChange={setSchedules}
-//               />
-//             </div>
-
-//             <div className="flex justify-end">
-//               <SquareButton
-//                 variant="primary"
-//                 size="lg"
-//                 onClick={() => setStep(2)}
-//               >
-//                 다음으로
-//               </SquareButton>
-//             </div>
-//           </section>
-//         </>
-//       )}
-
-//       {step === 2 && (
-//         <>
-//           <h2 className="font-heading2 text-label-strong">
-//             커피챗 등록하기
-//           </h2>
-//           <section className="border-border-subtler bg-fill-white px-spacing-xs py-spacing-md flex flex-col gap-[80px] rounded-sm border">
-//             <div className="gap-spacing-sm w-fulll flex flex-col">
-//               <label className="font-title4 text-label-strong">
-//                 이 커피챗은 어떤 분께 도움이 될까요?
-//               </label>
-//               <ul className="gap-pacing-4xs flex flex-col">
-//                 <li className="gap-spacing-4xs relative flex flex-row">
-//                   <label className="rounded-2xs font-label4-medium text-label-default border-border-subtle bg-fill-input-gray flex h-[50px] w-[50px] items-center justify-center border text-center">
-//                     대상
-//                   </label>
-//                   <input
-//                     type="text"
-//                     value={title}
-//                     onChange={(e) => setTitle(e.target.value)}
-//                     maxLength={40}
-//                     placeholder="도움을 줄 수 있는 대상에 대해 작성해주세요."
-//                     className="border-border-subtler bg-fill-white p-spacing-3xs font-caption2-medium text-label-default placeholder:text-label-subtler rounded-2xs focus:ring-label-primary w-full border focus:outline-none focus:ring-1"
-//                   />
-//                   <span className="text-label-subtler right-spacing-3xs font-caption2-medium absolute top-1/2 -translate-y-1/2 text-right">
-//                     {title.length}/40
-//                   </span>
-//                 </li>
-//               </ul>
-//               <ul className="gap-pacing-4xs flex flex-col">
-//                 <li className="gap-spacing-4xs relative flex flex-row">
-//                   <label className="rounded-2xs font-label4-medium text-label-default border-border-subtle bg-fill-input-gray flex h-[50px] w-[50px] items-center justify-center border text-center">
-//                     상황
-//                   </label>
-//                   <input
-//                     type="text"
-//                     value={title}
-//                     onChange={(e) => setTitle(e.target.value)}
-//                     maxLength={40}
-//                     placeholder="어떤 상황에 도움이 될 수 있을지 작성해주세요"
-//                     className="border-border-subtler bg-fill-white p-spacing-3xs font-caption2-medium text-label-default placeholder:text-label-subtler rounded-2xs focus:ring-label-primary w-full border focus:outline-none focus:ring-1"
-//                   />
-//                   <span className="text-label-subtler right-spacing-3xs font-caption2-medium absolute top-1/2 -translate-y-1/2 text-right">
-//                     {title.length}/40
-//                   </span>
-//                 </li>
-//               </ul>
-//               <ul className="gap-pacing-4xs flex flex-col">
-//                 <li className="gap-spacing-4xs relative flex flex-row">
-//                   <label className="rounded-2xs font-label4-medium text-label-default border-border-subtle bg-fill-input-gray flex h-[50px] w-[50px] items-center justify-center border text-center">
-//                     내용
-//                   </label>
-//                   <input
-//                     type="text"
-//                     value={title}
-//                     onChange={(e) => setTitle(e.target.value)}
-//                     maxLength={40}
-//                     placeholder="어떤 내용의 도움을 줄 수 있을지에 대해 작성해주세요."
-//                     className="border-border-subtler bg-fill-white p-spacing-3xs font-caption2-medium text-label-default placeholder:text-label-subtler rounded-2xs focus:ring-label-primary w-full border focus:outline-none focus:ring-1"
-//                   />
-//                   <span className="text-label-subtler right-spacing-3xs font-caption2-medium absolute top-1/2 -translate-y-1/2 text-right">
-//                     {title.length}/40
-//                   </span>
-//                 </li>
-//               </ul>
-//             </div>
-
-//             {/* 경험 목록 */}
-//             <div className="gap-spacing-sm flex w-full flex-col">
-//               <label className="font-title4 text-label-strong">
-//                 후배에게 나누실 경험 목록을 작성해주세요.
-//               </label>
-//               {experiences.map((exp, idx) => (
-//                 <div
-//                   key={idx}
-//                   className="p-spacing-3xs gap-spacing-sm rounded-xs bg-fill-footer-gray relative flex flex-col"
-//                 >
-//                   {/* 삭제 버튼 (한 개 이상일 때만 노출) */}
-//                   {experiences.length > 1 && (
-//                     <button
-//                       type="button"
-//                       onClick={() =>
-//                         setExperiences((prev) =>
-//                           prev.filter((_, i) => i !== idx),
-//                         )
-//                       }
-//                       className="text-label-subtlecursor-pointer right-spacing-3xs absolute top-2"
-//                     >
-//                       ✕
-//                     </button>
-//                   )}
-
-//                   {/* 경험 제목 */}
-//                   <div className="gap-spacing-4xs relative flex flex-col">
-//                     <label className="font-label4-medium text-label-deep">
-//                       경험 제목
-//                     </label>
-//                     <input
-//                       type="text"
-//                       value={exp.title}
-//                       onChange={(e) =>
-//                         updateExperience(idx, 'title', e.target.value)
-//                       }
-//                       maxLength={40}
-//                       placeholder="경험의 제목을 작성해주세요. (예: N사 최종 합격)"
-//                       className="border-border-subtler bg-fill-white px-spacing-3xs py-spacing-4xs font-caption2-medium text-label-default placeholder:text-label-subtle rounded-2xs focus:ring-label-primary w-full border focus:outline-none focus:ring-1"
-//                     />
-//                     <span className="text-label-subtle right-spacing-3xs absolute bottom-0.5 -translate-y-1/2 text-right text-sm">
-//                       {exp.title.length}/40
-//                     </span>
-//                   </div>
-
-//                   {/* 경험 내용 */}
-//                   <div className="gap-spacing-4xs relative flex flex-col">
-//                     <label className="font-label4-medium text-label-deep">
-//                       경험 내용
-//                     </label>
-//                     <textarea
-//                       value={exp.content}
-//                       onChange={(e) =>
-//                         updateExperience(
-//                           idx,
-//                           'content',
-//                           e.target.value,
-//                         )
-//                       }
-//                       maxLength={60}
-//                       placeholder="경험에 대해 간단하게 설명하는 글을 작성해주세요.(예: 면접에 10번 이상 떨어졌지만 칠전팔기 끝에 최종 합격했어요)"
-//                       className="border-border-subtler bg-fill-white px-spacing-3xs py-spacing-4xs font-caption2-medium text-label-default placeholder:text-label-subtle rounded-2xs focus:ring-label-primary min-h-[102px] w-full border focus:outline-none focus:ring-1"
-//                     />
-//                     <span className="text-label-subtle right-spacing-3xs bottom-spacing-4xs absolute text-right text-sm">
-//                       {exp.content.length}/60
-//                     </span>
-//                   </div>
-
-//                   {/* 주제 분류 */}
-//                   <div className="gap-spacing-4xs flex flex-col">
-//                     <label>주제분류</label>
-//                     <CategoryFilter
-//                       selected={exp.categories}
-//                       onChange={(vals) =>
-//                         updateExperience(idx, 'categories', vals)
-//                       }
-//                     />
-//                   </div>
-//                 </div>
-//               ))}
-//               {/* 경험 추가 버튼 */}
-//               <button
-//                 onClick={addExperience}
-//                 className="bg-fill-selected-orange rounded-xs py-spacing-4xs font-label3-medium text-label-primary w-full cursor-pointer text-center"
-//               >
-//                 + 경험 목록 추가
-//               </button>
-//             </div>
-
-//             {/* 커피챗 소개 */}
-//             <div className="gap-spacing-sm relative flex flex-col">
-//               <label className="font-title4 text-label-strong">
-//                 커피챗 소개글
-//               </label>
-//               <textarea
-//                 value={intro}
-//                 onChange={(e) => setIntro(e.target.value)}
-//                 maxLength={500}
-//                 placeholder="본인의 경험과 커피챗에 대해 소개하는 글을 작성해주세요."
-//                 className="border-border-subtler bg-fill-white p-spacing-2xs font-body3 text-label-default placeholder:text-label-subtle rounded-2xs focus:ring-label-primary min-h-[162px] w-full border focus:outline-none focus:ring-1"
-//               />
-//               <span className="text-label-subtle right-spacing-3xs bottom-spacing-4xs absolute text-right text-sm">
-//                 {intro.length}/500
-//               </span>
-//             </div>
-
-//             {/* 태그 */}
-//             <div className="gap-spacing-md flex w-fit flex-col">
-//               <div className="gap-spacing-2xs flex flex-col">
-//                 <label className="font-title4 text-label-strong">
-//                   프로필 카드에 노출될 경험 태그를 작성해주세요. (최대
-//                   5개)
-//                 </label>
-//                 <p className="font-caption2-medium text-label-subtle">
-//                   태그당 글자 수는 8자 이하로 제한됩니다.
-//                 </p>
-//               </div>
-//               <div className="gap-spacing-xs grid grid-cols-3">
-//                 {tags.map((tag, idx) => (
-//                   <div
-//                     key={idx}
-//                     className="border-border-subtler bg-fill-white p-spacing-4xs rounded-2xs gap-spacing-5xs flex items-center border"
-//                   >
-//                     <span className="text-label-subtle text-center">
-//                       #
-//                     </span>
-//                     <input
-//                       type="text"
-//                       value={tag}
-//                       onChange={(e) => {
-//                         const newTags = [...tags]
-//                         newTags[idx] = e.target.value
-//                         setTags(newTags)
-//                       }}
-//                       maxLength={8}
-//                       placeholder="태그 입력"
-//                       className="font-caption2-medium text-label-default placeholder:text-label-subtle flex-1 bg-transparent focus:outline-none"
-//                     />
-//                   </div>
-//                 ))}
-//               </div>
-//             </div>
-
-//             <div className="flex justify-between">
-//               <SquareButton
-//                 variant="secondary"
-//                 size="lg"
-//                 onClick={() => setStep(1)}
-//               >
-//                 이전
-//               </SquareButton>
-//               <SquareButton
-//                 variant="primary"
-//                 size="lg"
-//                 onClick={handleSubmit}
-//               >
-//                 등록하기
-//               </SquareButton>
-//             </div>
-//           </section>
-//         </>
-//       )}
-//     </main>
-//   )
-// }
-
 'use client'
 
 import { useState } from 'react'
@@ -442,6 +64,10 @@ export default function CoffeechatRegisterPage() {
 
   // ✅ Step2에서 경험 목록 추가
   const addExperience = () => {
+    if (experiences.length >= 6) {
+      alert('경험은 최대 6개까지만 추가할 수 있습니다.')
+      return
+    }
     setExperiences([
       ...experiences,
       { title: '', content: '', category: null },
@@ -541,19 +167,26 @@ export default function CoffeechatRegisterPage() {
       }
       // 5) 경험 목록 등록
       if (experiences.length > 0) {
-        // ✅ 경험마다 주제 선택 여부 확인
+        // ✅ 경험마다 주제/제목/내용 필수 확인
         for (const exp of experiences) {
           if (!exp.category) {
-            alert('경험마다 주제를 1개 이상 선택해야 합니다.')
+            alert('경험마다 주제를 선택해야 합니다.')
+            return
+          }
+          if (!exp.title.trim()) {
+            alert('경험 제목을 입력해주세요.')
+            return
+          }
+          if (!exp.content.trim()) {
+            alert('경험 내용을 입력해주세요.')
             return
           }
         }
-
         const expPayload = {
           groups: experiences.map((exp) => ({
-            topicName: exp.category, // ✅ 이제 topicName으로 보냄
-            experienceTitle: exp.title,
-            experienceContent: exp.content,
+            topicName: exp.category || 'UNDEFINED', // ✅ null이면 UNDEFINED로 대체
+            experienceTitle: exp.title.trim(),
+            experienceContent: exp.content.trim(),
           })),
         }
 
@@ -727,7 +360,7 @@ export default function CoffeechatRegisterPage() {
                           prev.filter((_, i) => i !== idx),
                         )
                       }
-                      className="text-label-subtlecursor-pointer right-spacing-3xs absolute top-2"
+                      className="text-label-subtle right-spacing-3xs absolute top-2 z-10 h-[24px] w-[24px] cursor-pointer"
                     >
                       ✕
                     </button>
@@ -789,12 +422,14 @@ export default function CoffeechatRegisterPage() {
                 </div>
               ))}
               {/* 경험 추가 버튼 */}
-              <button
-                onClick={addExperience}
-                className="bg-fill-selected-orange rounded-xs py-spacing-4xs font-label3-medium text-label-primary w-full cursor-pointer text-center"
-              >
-                + 경험 목록 추가
-              </button>
+              {experiences.length < 6 && (
+                <button
+                  onClick={addExperience}
+                  className="bg-fill-selected-orange rounded-xs py-spacing-4xs font-label3-medium text-label-primary w-full cursor-pointer text-center"
+                >
+                  + 경험 목록 추가
+                </button>
+              )}
             </div>
 
             {/* 커피챗 소개 */}

--- a/src/app/(WithLayout)/mypage/guide/mycoffeechat/page.tsx
+++ b/src/app/(WithLayout)/mypage/guide/mycoffeechat/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
 import SquareButton from '@/components/ui/Buttons/SquareButton'
@@ -10,6 +11,7 @@ import CategoryFilter from '@/components/ui/Filters/CategoryFilter'
 import JobFieldFilter from '@/components/ui/Filters/JobFieldFilter'
 import api from '@/lib/http/api'
 import { useAuthStore } from '@/store/useAuthStore'
+import { useModalStore } from '@/store/useModalStore'
 
 // 경험 항목 타입
 interface Experience {
@@ -41,6 +43,9 @@ const convertDayToEnum = (day: string) => {
 }
 
 export default function CoffeechatRegisterPage() {
+  const router = useRouter()
+  const { openModal } = useModalStore()
+
   // 단계 관리
   const [step, setStep] = useState(1)
 
@@ -88,12 +93,23 @@ export default function CoffeechatRegisterPage() {
   // 최종 제출
   const handleSubmit = async () => {
     try {
+      // 🔎 필수값 체크
+      if (!title.trim()) {
+        alert('커피챗 제목을 입력해주세요.')
+        return
+      }
+      if (!intro.trim()) {
+        alert('커피챗 소개글을 입력해주세요.')
+        return
+      }
+
       // 1) 커피챗 등록
       const chatRes = await api.post('/api/guides/me/coffeechat', {
         title,
         chatDescription: intro,
       })
       console.log('✅ 커피챗 등록 성공:', chatRes.data)
+
       // ✅ guideId 저장
       const newGuideId = chatRes.data?.data?.guide.id
       if (newGuideId) {
@@ -196,10 +212,21 @@ export default function CoffeechatRegisterPage() {
         console.log('✅ 경험 목록 등록 성공')
       }
 
-      alert('🎉 커피챗 등록 완료!')
+      openModal({
+        title: '등록 완료 🎉',
+        message: '커피챗이 성공적으로 등록되었습니다.',
+        confirmText: '확인',
+        onConfirm: () =>
+          router.push(`/coffeechatDetail/${newGuideId}`),
+      })
     } catch (err) {
       console.error('❌ 등록 실패:', err)
-      alert('등록 실패')
+      // 등록 실패
+      openModal({
+        title: '등록 실패 ⚠️',
+        message: '커피챗 등록에 실패했습니다. 다시 시도해주세요.',
+        confirmText: '닫기',
+      })
     }
   }
 
@@ -229,7 +256,7 @@ export default function CoffeechatRegisterPage() {
                   onChange={(e) => setTitle(e.target.value)}
                   maxLength={70}
                   placeholder="토론할 수 있는 커피챗 제목을 입력해주세요."
-                  className="border-border-subtler bg-fill-white p-spacing-3xs font-caption2-medium text-label-default placeholder:text-label-subtler rounded-2xs focus:ring-label-primary w-full border focus:outline-none focus:ring-1"
+                  className="border-border-subtler bg-fill-white p-spacing-3xs font-caption2-medium text-label-default placeholder:text-label-subtler rounded-2xs w-full border"
                 />
                 <span className="text-label-subtler right-spacing-3xs font-caption2-medium absolute top-1/2 -translate-y-1/2 text-right">
                   {title.length}/70
@@ -305,7 +332,7 @@ export default function CoffeechatRegisterPage() {
                     onChange={(e) => setWhoInput(e.target.value)}
                     maxLength={40}
                     placeholder="도움을 줄 수 있는 대상에 대해 작성해주세요."
-                    className="border-border-subtler bg-fill-white p-spacing-3xs font-caption2-medium text-label-default placeholder:text-label-subtler rounded-2xs focus:ring-label-primary w-full border focus:outline-none focus:ring-1"
+                    className="border-border-subtler bg-fill-white p-spacing-3xs font-caption2-medium text-label-default placeholder:text-label-subtler rounded-2xs w-full border"
                   />
                 </li>
               </ul>
@@ -320,7 +347,7 @@ export default function CoffeechatRegisterPage() {
                     onChange={(e) => setSolutionInput(e.target.value)}
                     maxLength={40}
                     placeholder="어떤 상황에 도움이 될 수 있을지 작성해주세요"
-                    className="border-border-subtler bg-fill-white p-spacing-3xs font-caption2-medium text-label-default placeholder:text-label-subtler rounded-2xs focus:ring-label-primary w-full border focus:outline-none focus:ring-1"
+                    className="border-border-subtler bg-fill-white p-spacing-3xs font-caption2-medium text-label-default placeholder:text-label-subtler rounded-2xs w-full border"
                   />
                 </li>
               </ul>
@@ -335,7 +362,7 @@ export default function CoffeechatRegisterPage() {
                     onChange={(e) => setHowInput(e.target.value)}
                     maxLength={40}
                     placeholder="어떤 내용의 도움을 줄 수 있을지에 대해 작성해주세요."
-                    className="border-border-subtler bg-fill-white p-spacing-3xs font-caption2-medium text-label-default placeholder:text-label-subtler rounded-2xs focus:ring-label-primary w-full border focus:outline-none focus:ring-1"
+                    className="border-border-subtler bg-fill-white p-spacing-3xs font-caption2-medium text-label-default placeholder:text-label-subtler rounded-2xs w-full border"
                   />
                 </li>
               </ul>
@@ -379,7 +406,7 @@ export default function CoffeechatRegisterPage() {
                       }
                       maxLength={40}
                       placeholder="경험의 제목을 작성해주세요. (예: N사 최종 합격)"
-                      className="border-border-subtler bg-fill-white px-spacing-3xs py-spacing-4xs font-caption2-medium text-label-default placeholder:text-label-subtle rounded-2xs focus:ring-label-primary w-full border focus:outline-none focus:ring-1"
+                      className="border-border-subtler bg-fill-white px-spacing-3xs py-spacing-4xs font-caption2-medium text-label-default placeholder:text-label-subtle rounded-2xs w-full border"
                     />
                     <span className="text-label-subtle right-spacing-3xs absolute bottom-0.5 -translate-y-1/2 text-right text-sm">
                       {exp.title.length}/40
@@ -402,7 +429,7 @@ export default function CoffeechatRegisterPage() {
                       }
                       maxLength={60}
                       placeholder="경험에 대해 간단하게 설명하는 글을 작성해주세요.(예: 면접에 10번 이상 떨어졌지만 칠전팔기 끝에 최종 합격했어요)"
-                      className="border-border-subtler bg-fill-white px-spacing-3xs py-spacing-4xs font-caption2-medium text-label-default placeholder:text-label-subtle rounded-2xs focus:ring-label-primary min-h-[102px] w-full border focus:outline-none focus:ring-1"
+                      className="border-border-subtler bg-fill-white px-spacing-3xs py-spacing-4xs font-caption2-medium text-label-default placeholder:text-label-subtle rounded-2xs min-h-[102px] w-full border"
                     />
                     <span className="text-label-subtle right-spacing-3xs bottom-spacing-4xs absolute text-right text-sm">
                       {exp.content.length}/60
@@ -442,7 +469,7 @@ export default function CoffeechatRegisterPage() {
                 onChange={(e) => setIntro(e.target.value)}
                 maxLength={500}
                 placeholder="본인의 경험과 커피챗에 대해 소개하는 글을 작성해주세요."
-                className="border-border-subtler bg-fill-white p-spacing-2xs font-body3 text-label-default placeholder:text-label-subtle rounded-2xs focus:ring-label-primary min-h-[162px] w-full border focus:outline-none focus:ring-1"
+                className="border-border-subtler bg-fill-white p-spacing-2xs font-body3 text-label-default placeholder:text-label-subtle rounded-2xs min-h-[162px] w-full border"
               />
               <span className="text-label-subtle right-spacing-3xs bottom-spacing-4xs absolute text-right text-sm">
                 {intro.length}/500
@@ -479,7 +506,7 @@ export default function CoffeechatRegisterPage() {
                       }}
                       maxLength={8}
                       placeholder="태그 입력"
-                      className="font-caption2-medium text-label-default placeholder:text-label-subtle flex-1 bg-transparent focus:outline-none"
+                      className="font-caption2-medium text-label-default placeholder:text-label-subtle flex-1 bg-transparent"
                     />
                   </div>
                 ))}

--- a/src/app/(WithLayout)/mypage/layout.tsx
+++ b/src/app/(WithLayout)/mypage/layout.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import dynamic from 'next/dynamic'
-import { useRouter } from 'next/navigation'
+// import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 
 import { useAuthStore } from '@/store/useAuthStore'
-import { useModalStore } from '@/store/useModalStore'
+// import { useModalStore } from '@/store/useModalStore'
 
 import MypageSidebarSkeleton from './_components/SideBars/MypageSidebarSkeleton'
 
@@ -24,25 +24,26 @@ export default function MypageLayout({
 }: {
   children: React.ReactNode
 }) {
-  const router = useRouter()
-  const { user, isLoggedIn } = useAuthStore()
-  const { openModal } = useModalStore()
+  // const router = useRouter()
+  // const { user, isLoggedIn } = useAuthStore()
+  // const { openModal } = useModalStore()
+  const { user } = useAuthStore()
 
   // ⬇️ 서버/클라 첫 렌더 DOM을 동일하게 만들기 위한 마운트 게이트
   const [mounted, setMounted] = useState(false)
   useEffect(() => setMounted(true), [])
 
-  useEffect(() => {
-    if (!isLoggedIn || !user) {
-      if (location.pathname === '/login') return
-      openModal({
-        title: '로그인 필요',
-        message: '마이페이지는 로그인 후 이용할 수 있습니다.',
-        confirmText: '로그인 페이지로 이동',
-        onConfirm: () => router.replace('/login'),
-      })
-    }
-  }, [isLoggedIn, user, openModal, router])
+  // useEffect(() => {
+  //   if (!isLoggedIn || !user) {
+  //     if (location.pathname === '/login') return
+  //     openModal({
+  //       title: '로그인 필요',
+  //       message: '마이페이지는 로그인 후 이용할 수 있습니다.',
+  //       confirmText: '로그인 페이지로 이동',
+  //       onConfirm: () => router.replace('/login'),
+  //     })
+  //   }
+  // }, [isLoggedIn, user, openModal, router])
 
   return (
     <>

--- a/src/app/(WithLayout)/mypage/rookie/profile/page.tsx
+++ b/src/app/(WithLayout)/mypage/rookie/profile/page.tsx
@@ -11,6 +11,7 @@ import { useAuthStore } from '@/store/useAuthStore'
 
 /* ===================== 매핑 테이블 ===================== */
 const JOB_FIELD_MAP: Record<string, string> = {
+  UNDEFINED: '미정',
   DESIGN: '디자인',
   PLANNING_STRATEGY: '기획/전략',
   MARKETING_PR: '마케팅/홍보',
@@ -20,17 +21,18 @@ const JOB_FIELD_MAP: Record<string, string> = {
 }
 
 const TOPIC_MAP: Record<string, string> = {
+  UNDEFINED: '미정',
   RESUME: '이력서',
   COVER_LETTER: '자소서',
   PORTFOLIO: '포트폴리오',
   INTERVIEW: '면접',
   PRACTICAL_WORK: '실무',
   ORGANIZATION_CULTURE: '조직문화',
-  HUMAN_RELATIONSHIP: '인간관계',
+  RELATIONSHIP: '인간관계',
   WORK_LIFE_BALANCE: '워라밸',
   PASS_EXPERIENCE: '합격 경험',
-  INDUSTRY_TRENDS: '업계 트렌드',
-  CAREER_SWITCH: '직무 전환',
+  INDUSTRY_TREND: '업계 트렌드',
+  CAREER_CHANGE: '직무 전환',
   JOB_CHANGE: '이직',
 }
 

--- a/src/components/ui/FileUpload/CoffeechatApplyFileUpload.tsx
+++ b/src/components/ui/FileUpload/CoffeechatApplyFileUpload.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+import clsx from 'clsx'
+import Image from 'next/image'
+import { useState } from 'react'
+
+import SquareButton from '@/components/ui/Buttons/SquareButton'
+
+type FileStatus = 'empty' | 'pending' | 'completed'
+
+interface CoffeechatApplyFileUploadProps {
+  className?: string
+  status?: FileStatus
+  files?: File[]
+  onChange?: (files: File[], status: FileStatus) => void
+}
+
+export default function CoffeechatApplyFileUpload({
+  className,
+  status: propStatus,
+  files: propFiles,
+  onChange,
+}: CoffeechatApplyFileUploadProps) {
+  const [internalStatus, setInternalStatus] =
+    useState<FileStatus>('empty')
+  const [internalFiles, setInternalFiles] = useState<File[]>([])
+
+  const status = propStatus ?? internalStatus
+  const files = propFiles ?? internalFiles
+
+  const handleFileChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const selectedFiles = e.target.files
+      ? Array.from(e.target.files)
+      : []
+    if (selectedFiles.length > 0) {
+      const file = selectedFiles[0] // ✅ 한 개만 선택
+      console.log('📂 업로드 파일 정보:', file)
+      console.log('파일 타입:', file.type)
+      console.log('파일 이름:', file.name)
+      console.log('파일 크기:', file.size, 'bytes')
+
+      if (!propFiles) setInternalFiles([file])
+      if (!propStatus) setInternalStatus('pending')
+
+      onChange?.([file], 'pending')
+
+      // 예시: 2초 후 인증 완료 처리
+      setTimeout(() => {
+        if (!propStatus) setInternalStatus('completed')
+        onChange?.([file], 'completed')
+      })
+    }
+  }
+
+  return (
+    <div
+      className={clsx(
+        'p-spacing-lg bg-fill-white border-border-light rounded-2xs gap-spacing-sm flex h-fit flex-col border',
+        className,
+      )}
+    >
+      {/* EMPTY 상태 */}
+      {status === 'empty' && (
+        <div className="gap-spacing-sm py-spacing-xl flex flex-col items-center justify-center text-center">
+          <p className="font-body2 text-label-subtle">
+            아직 등록한 파일이 없습니다.
+          </p>
+          <SquareButton
+            variant="primary"
+            size="md"
+          >
+            <label className="cursor-pointer">
+              파일 등록
+              <input
+                type="file"
+                accept="application/pdf"
+                className="hidden"
+                onChange={handleFileChange}
+              />
+            </label>
+          </SquareButton>
+        </div>
+      )}
+
+      {/* PENDING 상태 */}
+      {status === 'pending' && (
+        <>
+          <div className="rounded-2xs flex items-center justify-between">
+            <div className="py-spacing-4xs px-spacing-3xs bg-fill-disabled rounded-2xs border-border-subtle flex w-[564px] items-center justify-between border">
+              <span className="font-caption2-medium text-label-strong truncate">
+                {files.map((f) => f.name).join(', ')}
+              </span>
+              <Image
+                src="/images/buttons/checkboxGray.png"
+                alt="checkbox"
+                width={18}
+                height={18}
+              />
+            </div>
+            <SquareButton
+              variant="disabled"
+              size="md"
+            >
+              인증 대기중
+            </SquareButton>
+          </div>
+        </>
+      )}
+
+      {/* COMPLETED 상태 */}
+      {status === 'completed' && (
+        <>
+          <div className="rounded-2xs flex items-center justify-between">
+            <div className="py-spacing-4xs px-spacing-3xs bg-fill-disabled rounded-2xs border-border-subtle flex w-[564px] items-center justify-between border">
+              <span className="font-caption2-medium text-label-strong truncate">
+                {files.map((f) => f.name).join(', ')}
+              </span>
+              <Image
+                src="/images/buttons/checkboxPrimary.png"
+                alt="checkbox"
+                width={18}
+                height={18}
+              />
+            </div>
+            <SquareButton
+              variant="tertiary"
+              size="md"
+            >
+              <label className="cursor-pointer">
+                파일 변경
+                <input
+                  type="file"
+                  accept="application/pdf"
+                  className="hidden" // ✅ multiple 제거
+                  onChange={handleFileChange}
+                />
+              </label>
+            </SquareButton>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/ui/Filters/CategoryFilter.tsx
+++ b/src/components/ui/Filters/CategoryFilter.tsx
@@ -25,7 +25,7 @@ const GROUPS: Group[] = [
     options: [
       { label: '실무', value: 'PRACTICAL_WORK' },
       { label: '조직문화', value: 'ORGANIZATION_CULTURE' },
-      { label: '인간관계', value: 'HUMAN_RELATIONSHIP' },
+      { label: '인간관계', value: 'RELATIONSHIP' },
       { label: '워라밸', value: 'WORK_LIFE_BALANCE' },
     ],
   },
@@ -33,8 +33,8 @@ const GROUPS: Group[] = [
     title: '커리어',
     options: [
       { label: '합격 경험', value: 'PASS_EXPERIENCE' },
-      { label: '업계 트렌드', value: 'INDUSTRY_TRENDS' },
-      { label: '직무 전환', value: 'CAREER_SWITCH' },
+      { label: '업계 트렌드', value: 'INDUSTRY_TREND' },
+      { label: '직무 전환', value: 'CAREER_CHANGE' },
       { label: '이직', value: 'JOB_CHANGE' },
     ],
   },

--- a/src/components/ui/Filters/CategoryFilter.tsx
+++ b/src/components/ui/Filters/CategoryFilter.tsx
@@ -41,21 +41,14 @@ const GROUPS: Group[] = [
 ]
 
 interface CategoryFilterProps {
-  selected: string[] // ENUM 값 배열
-  onChange: (values: string[]) => void
+  selected: string | null // 단일 값
+  onChange: (value: string | null) => void
 }
 
 export default function CategoryFilter({
   selected,
   onChange,
 }: CategoryFilterProps) {
-  const toggle = (value: string) => {
-    const newValues = selected.includes(value)
-      ? selected.filter((v) => v !== value)
-      : [...selected, value]
-    onChange(newValues)
-  }
-
   return (
     <div className="border-border-subtler bg-fill-white p-spacing-md rounded-2xs border">
       <div className="gap-spacing-lg grid grid-cols-1 md:grid-cols-3">
@@ -71,9 +64,13 @@ export default function CategoryFilter({
                   className="font-label4-medium flex cursor-pointer items-center gap-2"
                 >
                   <input
-                    type="checkbox"
-                    checked={selected.includes(opt.value)}
-                    onChange={() => toggle(opt.value)}
+                    type="radio"
+                    checked={selected === opt.value}
+                    onChange={() =>
+                      onChange(
+                        selected === opt.value ? null : opt.value,
+                      )
+                    }
                     className="h-4 w-4 cursor-pointer accent-[var(--color-fill-primary)]"
                   />
                   {opt.label}

--- a/src/components/ui/Filters/JobFieldFilter.tsx
+++ b/src/components/ui/Filters/JobFieldFilter.tsx
@@ -15,21 +15,14 @@ const JOB_FIELDS: Option[] = [
 ]
 
 interface JobFieldFilterProps {
-  selected: string[] // ENUM 값 배열
-  onChange: (values: string[]) => void
+  selected: string | null // 단일 값
+  onChange: (value: string | null) => void
 }
 
 export default function JobFieldFilter({
   selected,
   onChange,
 }: JobFieldFilterProps) {
-  const toggle = (value: string) => {
-    const newValues = selected.includes(value)
-      ? selected.filter((v) => v !== value)
-      : [...selected, value]
-    onChange(newValues)
-  }
-
   return (
     <div className="border-border-subtler bg-fill-white p-spacing-md rounded-2xs border">
       <div className="gap-spacing-sm grid grid-cols-3">
@@ -40,8 +33,10 @@ export default function JobFieldFilter({
           >
             <input
               type="checkbox"
-              checked={selected.includes(opt.value)}
-              onChange={() => toggle(opt.value)}
+              checked={selected === opt.value}
+              onChange={() =>
+                onChange(selected === opt.value ? null : opt.value)
+              }
               className="h-4 w-4 cursor-pointer accent-[var(--color-fill-primary)]"
             />
             {opt.label}

--- a/src/store/useAuthStore.ts
+++ b/src/store/useAuthStore.ts
@@ -66,6 +66,7 @@ export type AuthState = {
   loading: boolean
   tokens: Tokens | null
   guideId: number | null
+  isHydrated: boolean
   init: () => Promise<void>
   login: (provider: Provider) => void
   loginTest: (nickname: string) => Promise<void>
@@ -76,6 +77,7 @@ export type AuthState = {
   setAuth: (payload: { user: User; tokens: Tokens | null }) => void
   refreshUser: () => Promise<void>
   setGuideId: (id: number) => void
+  setHydrated: () => void
 }
 
 //  추가
@@ -101,6 +103,9 @@ export const useAuthStore = create<AuthState>()(
       tokens: null,
       guideId: null,
       loading: false,
+      isHydrated: false,
+
+      setHydrated: () => set({ isHydrated: true }),
 
       init: async () => {
         set({ loading: true })
@@ -205,6 +210,12 @@ export const useAuthStore = create<AuthState>()(
         tokens: s.tokens,
         guideId: s.guideId,
       }),
+      onRehydrateStorage: () => (state, error) => {
+        if (error) {
+          console.error('rehydration error', error)
+        }
+        state?.setHydrated?.() // ⬅️ 여기서 안전하게 불러줌
+      },
     },
   ),
 )

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -5,6 +5,10 @@
 * {
   -webkit-tap-highlight-color: transparent;
 }
+*:focus-visible {
+  outline: none !important;
+  box-shadow: none !important;
+}
 html,
 body {
   width: 100vw;


### PR DESCRIPTION
# 🚀 What’s this PR about?

- 선배/후배 프로필 및 커피챗 관련 기능 개선 및 버그 수정

# 🛠️ What’s been done?

- 후배 프로필 수정 시 변경사항이 반영되지 않는 버그 수정
- 선배 커피챗 등록 UI 개선 및 등록 버그 수정
- 경험 목록 최대 6개 제한 및 삭제 기능 정상 동작하도록 수정
- 커피챗 예약 시 파일 업로드 컴포넌트 개선 및 에러 처리 추가
- auth에서 hydration 상태 관리 개선 → 새로고침 시 불필요한 모달 노출 문제 해결
- 가이드 커피챗 공개 여부 초기 상태 불러오기 로직 수정

# 🧪 Testing Details

- 후배 프로필 수정 후 UI 반영 여부 확인 완료
- 선배 커피챗 등록/삭제 시도 시 정상 동작 확인
- 경험 목록 7개 이상 추가 시 제한 동작 확인
- 파일 업로드 → 예약 요청 정상 처리 및 에러 케이스 모달 확인 완료
- 로그인 상태에서 새로고침 시 모달 비정상 노출 문제 해결 확인
- 가이드 공개 여부 토글 상태 저장 및 불러오기 정상 동작 확인

# 👀 Checkpoints for Reviewers

- 경험 목록 삭제 로직 및 최대 개수 제한 처리 방식 적절한지 확인
- auth hydration 처리 로직 단순화/안정화 여부 검토 필요
- 공개 여부 초기화 로직이 API 스펙과 잘 맞는지 확인
- 전체적인 상태 관리(store) 흐름 검토

# 📚 References & Resources

- API 명세서: `/api/guides/me/coffeechat`, `/api/guides/{guideId}/coffeechats`, `/api/guides/me/visibility`
- 내부 Zustand 상태 관리 구조 참고

# 🎯 Related Issues

- #53 
